### PR TITLE
Add connection string feature

### DIFF
--- a/config.h
+++ b/config.h
@@ -26,4 +26,8 @@
 "             (core dumped)" \
 "\e[0m\n"
 
+#define CONNECT_LINE_ENABLED
+#define CONNECT_LINE_INFORM_STRING
+#define CONNECT_LINE "kchat-connect"
+
 #endif

--- a/src/kchat.c
+++ b/src/kchat.c
@@ -88,6 +88,26 @@ static void client_disconnect(int id)
 
 void client_initialize(int connfd)
 {
+	#ifdef CONNECT_LINE_ENABLED
+	#ifdef CONNECT_LINE_INFORM_STRING
+	char connect_msg[512];
+	snprintf(connect_msg, 512, "Type \"%s\" to continue.\n", CONNECT_LINE);
+	write(connfd, connect_msg, strlen(connect_msg));
+	#endif
+	ssize_t bytesread;
+	char buf[bufsize + 1]; /* 1 more to leave space for '\0'. */
+	if ((bytesread = read(connfd, buf, bufsize)) > 0) {
+		buf[bytesread] = '\0';
+		trim(buf);
+		if (strcmp(CONNECT_LINE, buf) != 0) {
+			close(connfd);
+			return;
+		}
+	} else {
+			close(connfd);
+			return;
+	}
+	#endif
 	int id;
 	for (id = 0; id < maxclients; id++) {
 		/* If position is empty. */


### PR DESCRIPTION
This way users will first have to send the connection string, before being allowed to interact or even be recognized as connected in kchat.

It has the minor inconvenience of requiring supporting the connection string lines, and can be disabled by virtue of a compilation flag, the string being given to the user can also be disabled.